### PR TITLE
loaded get allows better keys

### DIFF
--- a/configerus/config.py
+++ b/configerus/config.py
@@ -226,6 +226,7 @@ class Config:
         if validator:
             self.validate(self.loaded[label].data, validator)
 
+        logger.debug("Loaded config {} : {}".format(label, self.loaded[label].data))
         return self.loaded[label]
 
     """ Formatter plugin usage and management """

--- a/configerus/contrib/dict/source.py
+++ b/configerus/contrib/dict/source.py
@@ -1,4 +1,6 @@
 from typing import Dict, Any
+import logging
+
 from configerus.config import Config
 
 

--- a/configerus/contrib/files/source.py
+++ b/configerus/contrib/files/source.py
@@ -2,9 +2,12 @@ import os
 import re
 import json
 import yaml
+import logging
 
 from configerus.config import Config
 from configerus.shared import tree_merge
+
+logger = logging.getLogger('configerus.contrib.source')
 
 # FileTypes that this class can use at this time
 FILESOURCE_FILETYPES = ["json", "yaml", "yml"]
@@ -78,7 +81,6 @@ class ConfigSourcePathPlugin:
                                     self.path, file), e))
 
                     assert file_config, "Empty config in {} from file {}".format(path, file)
-                    data = tree_merge(file_config, data)
                 elif extension == ".yml" or extension == ".yaml":
                     try:
                         file_config = yaml.load(matching_file, Loader=yaml.FullLoader)
@@ -89,10 +91,11 @@ class ConfigSourcePathPlugin:
                                     self.path, file), e))
 
                     assert file_config, "Empty config in {} [{}]".format(file, self.path)
-                    data = tree_merge(file_config, data)
 
                 else:
                     raise ValueError(
                         "Unknown config filetype. Cannot parse '{}' files, but it matches our regex".format(extension))
+
+                data = tree_merge(file_config, data)
 
         return data

--- a/configerus/test/test_1_shared.py
+++ b/configerus/test/test_1_shared.py
@@ -16,8 +16,40 @@ logger = logging.getLogger("shared")
 
 class BasicConstruct(unittest.TestCase):
 
-    def test_1_tree_get(self):
-        """ does tree_get() work """
+    def test_1_tree_reduce(self):
+        """ can we reduce trees to lists """
+        tree = ['1', '2', '3']
+        self.assertEqual(shared.tree_reduce(tree), tree)
+
+        tree = ['1', '2', ['3', '4']]
+        flat = ['1', '2', '3', '4']
+        self.assertEqual(shared.tree_reduce(tree, glue='.'), flat)
+
+        tree = ['1', '2', ['3', '4'], [['5'], '6', '7', [[['8']]]]]
+        flat = ['1', '2', '3', '4', '5', '6', '7', '8']
+        self.assertEqual(shared.tree_reduce(tree, glue='.'), flat)
+
+    def test_2_tree_reduce_ignore(self):
+        """ test the tree_reduce respects ignore """
+        tree = ['1', '2', ['3', '4'], [['5'], '6', '7', [[['8']]]]]
+        ignore = ['2', '4', '7']
+        flat = ['1', '3', '5', '6', '8']
+        self.assertEqual(shared.tree_reduce(tree, glue='.', ignore=ignore), flat)
+
+    def test_3_tree_reduce_real(self):
+        """ some gets that failed once upon a time """
+        tree = ['', 'validators']
+        ignore = ['', '']
+        flat = ['validators']
+        self.assertEqual(shared.tree_reduce(tree, glue='.', ignore=ignore), flat)
+
+        tree = [['backend.outputs', 'mke_cluster'], 'validators']
+        ignore = ['', '']
+        flat = ['backend', 'outputs', 'mke_cluster', 'validators']
+        self.assertEqual(shared.tree_reduce(tree, glue='.', ignore=ignore), flat)
+
+    def test_4_tree_get(self):
+        """ does tree_get() work with all sorts of messy keys """
 
         tree = {
             '1': {
@@ -31,31 +63,68 @@ class BasicConstruct(unittest.TestCase):
 
         self.assertEqual(shared.tree_get(tree, '1.2.3'), {'4': 'my value'})
         self.assertEqual(shared.tree_get(tree, '1.2.3.4'), 'my value')
+        self.assertEqual(shared.tree_get(tree, '1.2.3.4.'), 'my value')
+        self.assertEqual(shared.tree_get(tree, '1.2.3.4'), 'my value')
+        self.assertEqual(shared.tree_get(tree, ['1', '2', '3', '4']), 'my value')
+        self.assertEqual(shared.tree_get(tree, ['1.2', '3.4']), 'my value')
+        self.assertEqual(shared.tree_get(tree, ['1', ['2', '3.4']]), 'my value')
 
-    def test_2_tree_reduce_simple(self):
-        """ can we reduce trees to  dot notation strings """
+        self.assertEqual(shared.tree_get(tree, ['1', '2', '.', '', '3.', '.4']), 'my value')
+        self.assertEqual(shared.tree_get(tree, [['.', ''], '1.2.3.4', '..', ['.', ['.']]]), 'my value')
 
-        tree = ['1', '2', '3']
-        self.assertEqual(shared.tree_reduce(tree), '1.2.3')
-        self.assertEqual(shared.tree_reduce(tree, glue=':'), '1:2:3')
+    def test_5_tree_merge(self):
 
-    def test_3_tree_reduce_nested(self):
-        """ can we reduce trees to  dot notation strings """
+        source = {
+            '1': "source 1",
+            '2': "source 2",
+            '4': "source 4",
+            '5': {
+                '1': "source 5.1"
+            }
+        }
+        destination = {
+            '3': {
+                '1': "destination 3.1",
+                '2': {
+                    '1': "destination 3.2.1",
+                    '2': "destination 3.2.2"
+                }
+            },
+            '4': {
+                '1': "third 4.1"
+            },
+            '5': "third 5"
+        }
 
-        tree = ['1', '2', ['3', '4']]
-        self.assertEqual(shared.tree_reduce(tree, glue='.'), '1.2.3.4')
+        merged = shared.tree_merge(source, destination)
 
-        tree = ['1', '2', ['3', '4'], [['5'], '6', '7', [[['8']]]]]
-        self.assertEqual(shared.tree_reduce(tree, glue='.'), '1.2.3.4.5.6.7.8')
+        self.assertIsNotNone(merged)
+        self.assertEqual(shared.tree_get(merged, '3.1'), "destination 3.1")
+        self.assertEqual(shared.tree_get(merged, '4'), "source 4")
+        self.assertEqual(shared.tree_get(merged, '5.1'), "source 5.1")
 
-    def test_3_tree_reduce_ignore(self):
-        """ test the tree_reduce respects ignore """
+        third = {}
 
-        tree = ['1', '2', ['3', '4'], [['5'], '6', '7', [[['8']]]]]
-        ignore = ['2', '4', '7']
+    def test_get_listindexes(self):
+        """ can get reach into lists using numberic indexes """
 
-        self.assertEqual(shared.tree_reduce(tree, glue='.', ignore=ignore), '1.3.5.6.8')
+        test_list = [
+            '1.2 0',
+            '1.2 1',
+            '1.2 2',
+        ]
+        wrapper_dict = {'2': test_list}
+        tree = {
+            '1': wrapper_dict
+        }
 
-        tree = [['backend', 'outputs', 'mke_cluster'], 'validators']
-        ignore = ['', '']
-        self.assertEqual(shared.tree_reduce(tree, glue='.', ignore=ignore), 'backend.outputs.mke_cluster.validators')
+        self.assertEqual(shared.tree_get(tree, '1'), wrapper_dict)
+        self.assertEqual(shared.tree_get(tree, '1.2'), test_list)
+        self.assertEqual(shared.tree_get(tree, '1.2.0'), test_list[0])
+        self.assertEqual(shared.tree_get(tree, '1.2.2'), test_list[2])
+
+        with self.assertRaises(IndexError):
+            shared.tree_get(tree, '1.2.5')
+
+        with self.assertRaises(ValueError):
+            shared.tree_get(tree, '1.2.string')

--- a/configerus/test/test_2_config_get_behaviour.py
+++ b/configerus/test/test_2_config_get_behaviour.py
@@ -119,7 +119,10 @@ config_sources = [
             },
             'config.yaml': {
                 '5': "seventh 5 yaml",
-                '6': "seventh 6 yaml"
+                '6': "seventh 6 yaml",
+                '7': {
+                    '1': ['1']
+                }
             }
         }
     }
@@ -173,7 +176,7 @@ class ConfigBehaviour(unittest.TestCase):
         self.assertEqual(self.loaded_config.get('5'), "seventh 5 json")
 
     def test_get_multiple_keys(self):
-        """ test the the loaded config base value functions """
+        """ test the the loaded get of various key formats """
 
         third_3_base = self.loaded_config.get('3')
         third_3_2 = self.loaded_config.get('3.2')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = configerus
-version = 0.3.1
+version = 0.3.2
 description = Configuration manager
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
- you can use just lists of keys if you don't like the string dot notation
- you can index into lists if you pass an integer key step
- better ignore of bad formatting
- more testing
- version bump

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>