### PR TITLE
adding a source drops loaded configs

### DIFF
--- a/configerus/config.py
+++ b/configerus/config.py
@@ -169,6 +169,9 @@ class Config:
         supports, and the code here doesn't need to get fancy with function arguments
 
         """
+        # drop any loaded config
+        self.loaded = {}
+        # add the plugin to our list.
         return self.plugins.add_plugin(Type.SOURCE, plugin_id, instance_id, priority)
 
     def load(self, label: str, force_reload: bool = False, validator: str = ""):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = configerus
-version = 0.3.3
+version = 0.3.4
 description = Configuration manager
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
- this fixes an issue where loaded config labels get out of date.
- this means that retrieved loaded configs could be out of date.

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>