### PR TITLE
get() keys can now have hyphens

### DIFF
--- a/configerus/contrib/get/format.py
+++ b/configerus/contrib/get/format.py
@@ -5,7 +5,7 @@ from configerus.config import Config
 
 logger = logging.getLogger('configerus.contrib.get:formatter')
 
-CONFIG_DEFAULT_MATCH_PATTERN = r'\{((?P<source>\w+):)?(?P<key>[\w.]+)(\?(?P<default>[^\}]+))?\}'
+CONFIG_DEFAULT_MATCH_PATTERN = r'\{((?P<source>\w+):)?(?P<key>[-\w.]+)(\?(?P<default>[^\}]+))?\}'
 """ Default regex pattern used to string template, which needs to identify
 keys that can be used for replacement. Needs to have a named group for
 key, and can have named group for source and default

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = configerus
-version = 0.3.6
+version = 0.3.7
 description = Configuration manager
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>